### PR TITLE
Support refreshing statistics when car is unplugged

### DIFF
--- a/src/pyindrav2h/v2hdevice.py
+++ b/src/pyindrav2h/v2hdevice.py
@@ -2,6 +2,7 @@ import logging
 
 from .connection import Connection
 from . import V2H_MODES
+from .exceptions import V2HException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,8 +44,13 @@ class v2hDevice:
                                       "/latest")
         self.stats = s
         _LOGGER.debug(f"Stats: {s}")
-        a = await self.connection.get("/transactions/" + self.serial + 
-                                      "/00000000-0000-0000-0000-000000000000/active")
+        try:
+            a = await self.connection.get("/transactions/" + self.serial +
+                                          "/00000000-0000-0000-0000-000000000000/active")
+        except V2HException as e:
+            if e.code == 404:
+                # 404 response is returned when the car is not plugged in.
+                a = {}
         _LOGGER.debug(f"/active RESPONSE: {a}")
         self.active = a
     


### PR DESCRIPTION
When the car is unplugged, the `active` API endpoint returns an HTTP 404 status which causes the `v2hDevice.refresh_stats` method to error. However, the majority of the stats are still available and valid so `refresh_stats` should still return the available stats without error.

This change simply wraps the call to the `active` endpoint in a try/except block and sets the active attibrute to an empty dict; this is the same result as if the API call had not been made in the first place and so seems the most appropriate placeholder value.

Fixes #16