### PR TITLE
Add support for preset schedules

### DIFF
--- a/src/pyindrav2h/cli.py
+++ b/src/pyindrav2h/cli.py
@@ -50,9 +50,9 @@ async def main(args):
             if command == args.command:
                 print(await client.device.select_charger_mode(mode))
     elif args.command == "get-schedule":
-        print(await client.schedule.get_schedule(client.device))
+        print(client.device.loadedSchedule)
     elif args.command == "set-schedule":
-        print(await client.schedule.set_schedule(client.device, args.schedule))
+        print(await client.device.set_loaded_schedule(args.schedule))
 
 def cli():
     config = configparser.ConfigParser()

--- a/src/pyindrav2h/cli.py
+++ b/src/pyindrav2h/cli.py
@@ -49,6 +49,10 @@ async def main(args):
         for mode, command in V2H_MODES.items():
             if command == args.command:
                 print(await client.device.select_charger_mode(mode))
+    elif args.command == "get-schedule":
+        print(await client.schedule.get_schedule(client.device))
+    elif args.command == "set-schedule":
+        print(await client.schedule.set_schedule(client.device, args.schedule))
 
 def cli():
     config = configparser.ConfigParser()
@@ -79,6 +83,10 @@ def cli():
     subparsers.add_parser("charge", help="set mode to CHARGE")
     subparsers.add_parser("discharge", help="set mode to discharge")
     subparsers.add_parser("schedule", help="return to scheuduled mode")
+    subparsers.add_parser("get-schedule", help="get the currently-active schedule")
+    set_schedule = subparsers.add_parser("set-schedule",
+                                         help="set the active schedule")
+    set_schedule.add_argument("schedule", help="ID of the schedule to use")
 
     args = parser.parse_args()
 

--- a/src/pyindrav2h/cli.py
+++ b/src/pyindrav2h/cli.py
@@ -50,7 +50,7 @@ async def main(args):
             if command == args.command:
                 print(await client.device.select_charger_mode(mode))
     elif args.command == "get-schedule":
-        print(client.device.loadedSchedule)
+        print(client.device.showSchedule())
     elif args.command == "set-schedule":
         print(await client.device.set_loaded_schedule(args.schedule))
 

--- a/src/pyindrav2h/v2hclient.py
+++ b/src/pyindrav2h/v2hclient.py
@@ -1,7 +1,6 @@
 import logging
 from .connection import Connection
 from .v2hdevice import v2hDevice
-from .v2hschedule import v2hSchedule
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -11,16 +10,13 @@ class v2hClient:
     ) -> None:
         self._connection = connection
         self._device = None
-        self._schedule = None
 
     async def refresh(self):
         if self._device is None:
             self._device = v2hDevice(self._connection)
         await self._device.refresh_device_info()
         await self._device.refresh_stats()
-        if self._schedule is None:
-            self._schedule = v2hSchedule(self._connection)
-        await self._schedule.refresh_schedules()
+        await self._device.refresh_loaded_schedule()
     
     async def refresh_device(self):
         if self._device is None:
@@ -32,10 +28,11 @@ class v2hClient:
             self._device = v2hDevice(self._connection)
         await self._device.refresh_stats()
 
+    async def refresh_loaded_schedule(self):
+        if self._device is None:
+            self._device = v2hDevice(self._connection)
+        await self._device.refresh_loaded_schedule()
+
     @property
     def device(self):
         return self._device
-
-    @property
-    def schedule(self):
-        return self._schedule

--- a/src/pyindrav2h/v2hclient.py
+++ b/src/pyindrav2h/v2hclient.py
@@ -1,6 +1,7 @@
 import logging
 from .connection import Connection
 from .v2hdevice import v2hDevice
+from .v2hschedule import v2hSchedule
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -10,12 +11,16 @@ class v2hClient:
     ) -> None:
         self._connection = connection
         self._device = None
+        self._schedule = None
 
     async def refresh(self):
         if self._device is None:
             self._device = v2hDevice(self._connection)
         await self._device.refresh_device_info()
         await self._device.refresh_stats()
+        if self._schedule is None:
+            self._schedule = v2hSchedule(self._connection)
+        await self._schedule.refresh_schedules()
     
     async def refresh_device(self):
         if self._device is None:
@@ -30,3 +35,7 @@ class v2hClient:
     @property
     def device(self):
         return self._device
+
+    @property
+    def schedule(self):
+        return self._schedule

--- a/src/pyindrav2h/v2hdevice.py
+++ b/src/pyindrav2h/v2hdevice.py
@@ -3,15 +3,18 @@ import logging
 from .connection import Connection
 from . import V2H_MODES
 from .exceptions import V2HException
+from .v2hschedule import v2hSchedule
 
 _LOGGER = logging.getLogger(__name__)
 
 class v2hDevice:
     def __init__(self, connection: Connection) -> None:
         self.connection = connection
+        self._schedule = v2hSchedule(connection)
         self.data = {}
         self.stats = {}
         self.active = {}
+        self._loaded_schedule = None
 
     async def refresh_device_info(self):
         # d = await self.connection.get("/authorize/validate")
@@ -53,6 +56,17 @@ class v2hDevice:
                 a = {}
         _LOGGER.debug(f"/active RESPONSE: {a}")
         self.active = a
+
+    async def refresh_loaded_schedule(self):
+        s = await self._schedule.get_schedule(self)
+        self._loaded_schedule = s["id"]
+
+    async def set_loaded_schedule(self, schedule_id):
+        await self._schedule.set_schedule(self, schedule_id)
+        # Confirm schedule update successful.
+        await self.refresh_loaded_schedule()
+        if self._loaded_schedule != schedule_id:
+            raise V2HException(f"Failed to set active schedule to {schedule_id}.")
     
     @property
     def id(self):
@@ -199,6 +213,10 @@ class v2hDevice:
         except KeyError as e:
             _LOGGER.debug(f"KeyError [{e}] in function isInterrupted")
             return None
+
+    @property
+    def loadedSchedule(self):
+        return self._loaded_schedule
     
     
     def showDevice(self):

--- a/src/pyindrav2h/v2hdevice.py
+++ b/src/pyindrav2h/v2hdevice.py
@@ -225,7 +225,7 @@ class v2hDevice:
         ret = ret + "--- Device info ---\n"
         ret = ret + f"Device UID: {self.serial}\n"
         ret = ret + f"Last On date: {self.lastOn}\n"
-        ret = ret + f"Device active: {self.isActive}"
+        ret = ret + f"Device active: {self.isActive}\n"
 
         return ret
 
@@ -249,8 +249,21 @@ class v2hDevice:
         ret = ret + f"Schedule active?: {not self.isInterrupted}\n"
         return ret
 
+    def showSchedule(self):
+        ret = ""
+
+        ret = ret + "--- Loaded schedule ---\n"
+        ret = ret + f"Schedule ID: {self.loadedSchedule}\n"
+        props = self._schedule.describe_schedule(self.loadedSchedule)
+        ret = ret + f"Schedule properties: {props}\n"
+        return ret
+
     def showAll(self):
-        return self.showDevice() + "\n\n" + self.showStats()
+        return (
+            self.showDevice()
+            + "\n" + self.showStats()
+            + "\n" + self.showSchedule()
+        )
   
     def getDevices(self):
         return self.data["devices"]

--- a/src/pyindrav2h/v2hschedule.py
+++ b/src/pyindrav2h/v2hschedule.py
@@ -24,26 +24,28 @@ class v2hSchedule:
         - recurrance: how often the rule runs ('MO,TU,WE,TH,FR,SA,SU') is
           all week.
 
-    The available presets are expected to change infrequently, and can be
-    downloaded and cached using v2hSchedule.refresh_schedules().
+    The available presets are expected to change infrequently and can
+    be downloaded and cached using v2hSchedule.refresh_schedules().
+    Each time a get or set of the current schedule is performed, the
+    latest available list of presets is retrived automatically too.
 
     The available presets are accessible through vh2Schedule.presets,
     which returns a dictionary keyed by the schedule IDs, one entry for
     each schedule as a dictionary in the format listed above.
 
     To make a V2H device use a preset schedule, call
-    `v2hSchedule.set_schedule(device, schedule), with device being
-    a v2hDevice instance and schedule being the ID of one of the
+    `v2hSchedule.set_schedule(device, schedule_id), with device being
+    a v2hDevice instance and schedule_id being the ID of one of the
     available presets. An error occurs if a preset is asked for which
-    does not exist in the local cache. It may be prudent to call
-    `refresh_schedules` before calling `set_schedule` in case the available
-    list of schedules has changed since it was last fetched.
+    does not exist remotely, noting that the list of available presets
+    on Indra's servers may have changed since the last time the local
+    client retrived them before the `set_schedule` call.
     """
     def __init__(
         self, connection: Connection
     ) -> None:
         self._connection = connection
-        self._preset_schedules = None
+        self._preset_schedules = {}
 
     async def refresh_schedules(self):
         scheds = await self._connection.get('/trials/v2h/schedules/presets/')
@@ -66,10 +68,13 @@ class v2hSchedule:
         active = await self._connection.get(
             f'/trials/v2h/devices/{device.serial}/schedules/active'
         )
+        if active['presetSourceId'] not in self.presets:
+            # New schedules added and set since last refresh.
+            await self.refresh_schedules()
         active_schedule = self.presets[active['presetSourceId']]
         return active_schedule
 
-    async def set_schedule(self, device, schedule):
+    async def set_schedule(self, device, schedule_id):
         """
         Set the active schedule of a device.
 
@@ -78,7 +83,8 @@ class v2hSchedule:
         device:   a v2hDevice instance of a charger device.
         schedule: the ID of one of the schedules in v2hSchedule.presets
         """
-        if schedule not in self.presets:
+        await self.refresh_schedules()
+        if schedule_id not in self.presets:
             raise ValueError(
                 'schedule must be one of the IDs in v2hSchedule.presets.\n'
                 'Use v2hSchedule.refresh_schedules() to get an up-to-date list '
@@ -86,7 +92,7 @@ class v2hSchedule:
             )
         resp = await self._connection.post(
             '/trials/v2h/schedules',
-            {'deviceUid': device.serial, 'presetSourceID': schedule}
+            {'deviceUid': device.serial, 'presetSourceID': schedule_id}
         )
         return resp
 

--- a/src/pyindrav2h/v2hschedule.py
+++ b/src/pyindrav2h/v2hschedule.py
@@ -1,6 +1,5 @@
 import logging
 from .connection import Connection
-from .v2hdevice import v2hDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/pyindrav2h/v2hschedule.py
+++ b/src/pyindrav2h/v2hschedule.py
@@ -1,4 +1,5 @@
 import logging
+from textwrap import dedent
 from .connection import Connection
 
 _LOGGER = logging.getLogger(__name__)
@@ -98,3 +99,26 @@ class v2hSchedule:
     @property
     def presets(self):
         return {schedule['id']: schedule for schedule in self._preset_schedules}
+
+    def describe_schedule(self, schedule_id):
+        """
+        Return  details of the preset schedule specified by schedule_id
+        as a multi-line string for printing.
+        """
+        schedule = self.presets[schedule_id]
+        output = "\n".join([
+            f"Schedule ID: {schedule_id}",
+            f"Name: {schedule["name"]}",
+            f"Description: {schedule["description"]}",
+            "Rules:\n"
+        ])
+        for rule in schedule["rules"]:
+            output += dedent(
+                f"""\
+                - Start time: {rule["start"]}
+                  End time: {rule["end"]}
+                  Mode: {rule["mode"]}
+                  Recurrence: {rule["recurrence"]}
+                """
+            )
+        return output

--- a/src/pyindrav2h/v2hschedule.py
+++ b/src/pyindrav2h/v2hschedule.py
@@ -1,0 +1,94 @@
+import logging
+from .connection import Connection
+from .v2hdevice import v2hDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+class v2hSchedule:
+    """
+    Support for preset schedules.
+
+    As of June 2026 the Indra API supports schedules at the
+    `/trials/v2h/schedules` endpoint. Info on each preset is returned as a JSON
+    object with the following properties:
+
+      - id: a unique identifier for the preset
+      - name: a human-readable name
+      - description: a few sentences describing the modes and times of
+        the preset.
+      - rules: a list of objects describing each different window of
+        operation, one entry per window:
+        - start: the start time in HH:MM format.
+        - end: the end time in HH:MM format.
+        - mode: the charger mode (one of the V2H_MODES keys).
+        - recurrance: how often the rule runs ('MO,TU,WE,TH,FR,SA,SU') is
+          all week.
+
+    The available presets are expected to change infrequently, and can be
+    downloaded and cached using v2hSchedule.refresh_schedules().
+
+    The available presets are accessible through vh2Schedule.presets,
+    which returns a dictionary keyed by the schedule IDs, one entry for
+    each schedule as a dictionary in the format listed above.
+
+    To make a V2H device use a preset schedule, call
+    `v2hSchedule.set_schedule(device, schedule), with device being
+    a v2hDevice instance and schedule being the ID of one of the
+    available presets. An error occurs if a preset is asked for which
+    does not exist in the local cache. It may be prudent to call
+    `refresh_schedules` before calling `set_schedule` in case the available
+    list of schedules has changed since it was last fetched.
+    """
+    def __init__(
+        self, connection: Connection
+    ) -> None:
+        self._connection = connection
+        self._preset_schedules = None
+
+    async def refresh_schedules(self):
+        scheds = await self._connection.get('/trials/v2h/schedules/presets/')
+        self._preset_schedules = scheds
+
+    async def get_schedule(self, device):
+        """
+        Get the currently-active schedule of a charger.
+
+        Parameters
+        ----------
+        device: a v2hDevice instance of a charger device.
+
+        Returns
+        -------
+
+        The ID of the currently-active schedule. This can be used as a
+        key to v2hSchedule.presets to retrieve the full schedule details.
+        """
+        active = await self._connection.get(
+            f'/trials/v2h/devices/{device.serial}/schedules/active'
+        )
+        active_schedule = self.presets[active['presetSourceId']]
+        return active_schedule
+
+    async def set_schedule(self, device, schedule):
+        """
+        Set the active schedule of a device.
+
+        Parameters
+        ----------
+        device:   a v2hDevice instance of a charger device.
+        schedule: the ID of one of the schedules in v2hSchedule.presets
+        """
+        if schedule not in self.presets:
+            raise ValueError(
+                'schedule must be one of the IDs in v2hSchedule.presets.\n'
+                'Use v2hSchedule.refresh_schedules() to get an up-to-date list '
+                'of available presets.'
+            )
+        await self._connection.post(
+            '/trials/v2h/schedules',
+            {'deviceUid': device.serial, 'presetSourceID': schedule}
+        )
+
+    @property
+    def presets(self):
+        return {schedule['id']: schedule for schedule in self._preset_schedules}

--- a/src/pyindrav2h/v2hschedule.py
+++ b/src/pyindrav2h/v2hschedule.py
@@ -84,10 +84,11 @@ class v2hSchedule:
                 'Use v2hSchedule.refresh_schedules() to get an up-to-date list '
                 'of available presets.'
             )
-        await self._connection.post(
+        resp = await self._connection.post(
             '/trials/v2h/schedules',
             {'deviceUid': device.serial, 'presetSourceID': schedule}
         )
+        return resp
 
     @property
     def presets(self):


### PR DESCRIPTION
Add a new class for interacting with the preset schedules made available by Indra. The class can get and set the currently-active schedule for a V2H device, and also maintains a list of available schedules which can be populated on startup and periodically thereafter (for example, just before setting a schedule to check it's still a valid option).

The Indra API returns the schedules as a list of JSON objects, which is a little cumbersome to work with. The `presets` property presents this instead as a dictionary keyed by the schedule ID - which is actually pretty descriptive on its own. The rules list for each schedule can be used to programmatically determine a suitable one to use, e.g. by considering that a user would likely want to load match during peak hours and perhaps use one of the "V2H Condensed" schedules to charge for a certain number of hours off-peak to achieve a desired SOC. Implementing this sort of logic is out of the scope of this contribution however: it's best left to downstream user scripts (or HomeAssistant automations).

A couple more options have been added to the CLI to support this functionality.

By splitting the schedules from the device, it should be neater to modify in the future should Indra change how the schedules work, for example adding custom schedules (one day? One can but hope). An instance of the schedule class is available to the v2hClient instance so it's accessible for example in the HomeAssistant integration.

Example CLI usage:

```bash
(v2h) jack@jack-MacBookPro:~/Software/pyindrav2h$ indracli --help
usage: indracli [-h] [-u EMAIL] [-p PASSWORD] [-d] {statistics,device,alldevices,all,loadmatch,idle,exportmatch,charge,discharge,schedule,get-schedule,set-schedule} ...

Indra V2H CLI

positional arguments:
  {statistics,device,alldevices,all,loadmatch,idle,exportmatch,charge,discharge,schedule,get-schedule,set-schedule}
    statistics          show device statistics
    device              show device info
    alldevices          show data on all available devices
    all                 show all info
    loadmatch           set mode to load matching
    idle                set mode to IDLE
    exportmatch         set mode to export matching
    charge              set mode to CHARGE
    discharge           set mode to discharge
    schedule            return to scheuduled mode
    get-schedule        get the currently-active schedule
    set-schedule        set the active schedule

options:
  -h, --help            show this help message and exit
  -u EMAIL, --email EMAIL
  -p PASSWORD, --password PASSWORD
  -d, --debug

(v2h) jack@jack-MacBookPro:~/Software/pyindrav2h$ indracli get-schedule
{'id': 'V2H-Solar--0000-7H-Export-Match', 'name': 'V2H Solar (0000 7H Export Match)', 'description': 'V2H Solar will charge your EV during a specific time window, starting at the times indicated in brackets using only any surplus solar (Export Match).\n\nThis schedule will then operate in Load Match mode the rest of the time, to meet the energy needs of your household by discharging your EV battery to the home as required.', 'rules': [{'start': '00:00', 'end': '07:00', 'mode': 'EXPORT_MATCH', 'recurrence': 'MO,TU,WE,TH,FR,SA,SU'}, {'start': '07:00', 'end': '00:00', 'mode': 'LOAD_MATCH', 'recurrence': 'MO,TU,WE,TH,FR,SA,SU'}]}
(v2h) jack@jack-MacBookPro:~/Software/pyindrav2h$ indracli set-schedule V2H-Classic-Solar--0000-1H-Charge--0100-6H-Export-Match
{'deviceUid': '851542a2-0ce2-4607-b628-65c343d4a803', 'presetSourceId': 'V2H-Classic-Solar--0000-1H-Charge--0100-6H-Export-Match', 'rules': [{'start': '00:00', 'end': '01:00', 'mode': 'CHARGE', 'recurrence': 'MO,TU,WE,TH,FR,SA,SU'}, {'start': '01:00', 'end': '07:00', 'mode': 'EXPORT_MATCH', 'recurrence': 'MO,TU,WE,TH,FR,SA,SU'}, {'start': '07:00', 'end': '00:00', 'mode': 'LOAD_MATCH', 'recurrence': 'MO,TU,WE,TH,FR,SA,SU'}]}
(v2h) jack@jack-MacBookPro:~/Software/pyindrav2h$ indracli get-schedule
{'id': 'V2H-Classic-Solar--0000-1H-Charge--0100-6H-Export-Match', 'name': 'V2H Classic Solar (0000 1H Charge, 6H Export Match)', 'description': 'V2H Classic will charge your EV during a specific time window, starting at the times indicated in brackets - using either energy from the grid or from surplus solar.\n\nThis schedule will then operate in Load Match mode the rest of the time, to meet the energy needs of your household by discharging your EV battery to the home as required.\n\nThis option works well for those with a dual-rate tariffs with solar panels who are looking to conserve battery state of charge for use later in the evening.', 'rules': [{'start': '00:00', 'end': '01:00', 'mode': 'CHARGE', 'recurrence': 'MO,TU,WE,TH,FR,SA,SU'}, {'start': '01:00', 'end': '07:00', 'mode': 'EXPORT_MATCH', 'recurrence': 'MO,TU,WE,TH,FR,SA,SU'}, {'start': '07:00', 'end': '00:00', 'mode': 'LOAD_MATCH', 'recurrence': 'MO,TU,WE,TH,FR,SA,SU'}]}
```

And Python usage:

```python
>>> from pyindrav2h.connection import Connection
>>> from pyindrav2h.v2hclient import v2hClient
>>> conn = Connection(username, passwd)
>>> client = v2hClient(conn)
>>> await client.refresh()  # Loads device stats and also populates schedule presets.
>>> current_schedule = await client.schedule.get_schedule(client.device)
>>> print(current_schedule['id'])
V2H-Classic-Solar--0000-1H-Charge--0100-6H-Export-Match
>>> await client.schedule.set_schedule(client.device, "V2H-Solar--0000-7H-Export-Match")
>>> current_schedule = await client.schedule.get_schedule(client.device)
>>> print(current_schedule['id'])
V2H-Solar--0000-7H-Export-Match
```
